### PR TITLE
<CARRY> fix Makefile to run e2e tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,7 +13,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 WORKDIR /workspace
 COPY . .
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -mod=vendor -a -o manager cmd/kueue/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -a -o manager cmd/kueue/main.go
 
 FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE}
 WORKDIR /

--- a/Makefile-test-ocp.mk
+++ b/Makefile-test-ocp.mk
@@ -1,7 +1,3 @@
-include Makefile
-include Makefile-deps.mk
-include Makefile-test.mk
-
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ARTIFACTS ?= $(PROJECT_DIR)/bin
 
@@ -21,12 +17,39 @@ version_pkg = sigs.k8s.io/kueue/pkg/version
 LD_FLAGS += -X '$(version_pkg).GitVersion=$(GIT_TAG)'
 LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
 
+# Use go.mod go version as source.
+KUSTOMIZE_OCP_VERSION ?= $(shell $(GO_CMD) list -m -mod=mod -f '{{.Version}}' sigs.k8s.io/kustomize/kustomize/v5)
+GINKGO_OCP_VERSION ?= $(shell $(GO_CMD) list -m -mod=mod -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+YQ_OCP_VERSION ?= $(shell $(GO_CMD) list -m -mod=mod -f '{{.Version}}' github.com/mikefarah/yq/v4)
+
+KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
+.PHONY: kustomize-ocp
+kustomize-ocp: ## Download kustomize locally if necessary.
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install -mod=mod sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_OCP_VERSION)
+
+GINKGO = $(PROJECT_DIR)/bin/ginkgo
+.PHONY: ginkgo-ocp
+ginkgo-ocp: ## Download ginkgo locally if necessary.
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_OCP_VERSION)
+
+YQ = $(PROJECT_DIR)/bin/yq
+.PHONY: yq-ocp
+yq-ocp: ## Download yq locally if necessary.
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install -mod=mod github.com/mikefarah/yq/v4@$(YQ_OCP_VERSION)
+
 .PHONY: test-e2e-ocp
-test-e2e-ocp: kustomize ginkgo yq gomod-download dep-crds kueuectl ginkgo-top run-test-e2e-ocp-singlecluster
+test-e2e-ocp: kustomize-ocp ginkgo-ocp yq-ocp kueuectl-ocp ginkgo-top-ocp run-test-e2e-ocp-singlecluster
 run-test-e2e-ocp-singlecluster:
 	@echo "Running e2e tests on OpenShift cluster ($(shell oc whoami --show-server))"
-		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
-		E2E_TARGET_FOLDER="singlecluster" \
-		./hack/e2e-test-ocp.sh
+	ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
+	E2E_TARGET_FOLDER="singlecluster" \
+	./hack/e2e-test-ocp.sh
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/$@/e2e.json > $(ARTIFACTS)/$@/e2e-top.yaml
 
+.PHONY: ginkgo-top-ocp
+ginkgo-top-ocp:
+	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(PROJECT_DIR)/bin/ginkgo-top ./pkg/openshift/ginkgo-top
+
+.PHONY: kueuectl-ocp
+kueuectl-ocp:
+	CGO_ENABLED=$(CGO_ENABLED) $(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(PROJECT_DIR)/bin/kubectl-kueue cmd/kueuectl/main.go

--- a/pkg/openshift/ginkgo-top/ginkgo-top.go
+++ b/pkg/openshift/ginkgo-top/ginkgo-top.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"cmp"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"time"
+
+	gtypes "github.com/onsi/ginkgo/v2/types"
+	"gopkg.in/yaml.v3"
+)
+
+type SpecDescription struct {
+	Suite              string
+	ContainerHierarchy []string
+	Name               string
+	Duration           time.Duration
+	Events             []Event
+}
+
+type Event struct {
+	Message  string
+	Location string
+	Duration time.Duration
+}
+
+var (
+	reportPath = flag.String("i", "ginkgo.json", "input file name")
+	maxCount   = flag.Uint("maxCount", 0, "maximum number of items")
+	withEvents = flag.Bool("withEvents", true, "show events")
+)
+
+func main() {
+	flag.Parse()
+	reprtData, err := os.ReadFile(*reportPath)
+	if err != nil {
+		panic(err)
+	}
+
+	report := []gtypes.Report{}
+	err = json.Unmarshal(reprtData, &report)
+	if err != nil {
+		panic(err)
+	}
+
+	flattenSpecs := []SpecDescription{}
+	for _, r := range report {
+		for _, s := range r.SpecReports {
+			sd := SpecDescription{
+				Suite:              r.SuiteDescription,
+				ContainerHierarchy: s.ContainerHierarchyTexts,
+				Name:               s.LeafNodeText,
+				Duration:           s.RunTime,
+			}
+			if *withEvents {
+				for _, ev := range s.SpecEvents {
+					if ev.Duration > 0 {
+						event := Event{
+							Location: ev.CodeLocation.String(),
+							Message:  fmt.Sprintf("%s (%s)", ev.Message, ev.NodeType),
+							Duration: ev.Duration,
+						}
+						sd.Events = append(sd.Events, event)
+					}
+				}
+				slices.SortFunc(sd.Events, func(a, b Event) int {
+					return cmp.Compare(b.Duration, a.Duration)
+				})
+			}
+			flattenSpecs = append(flattenSpecs, sd)
+		}
+	}
+	slices.SortFunc(flattenSpecs, func(a, b SpecDescription) int {
+		return cmp.Compare(b.Duration, a.Duration)
+	})
+
+	yout := yaml.NewEncoder(os.Stdout)
+	if *maxCount > 0 {
+		yout.Encode(flattenSpecs[:min(int(*maxCount), len(flattenSpecs))])
+	} else {
+		yout.Encode(flattenSpecs)
+	}
+}


### PR DESCRIPTION
I'm testing this change here: https://github.com/openshift/release/pull/61861. I can't run the e2e tests using my fork in `openshift/release`, but I wanted to fix the Go dependency issues that this PR will certainly address.