### PR TITLE
<CARRY> e2e-upstream-test: preparation to run pod/statefulset/deployment tests

### DIFF
--- a/Makefile-test-ocp.mk
+++ b/Makefile-test-ocp.mk
@@ -96,6 +96,16 @@ run-test-e2e-ocp-singlecluster:
 	./hack/e2e-test-ocp.sh
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/$@/e2e.json > $(ARTIFACTS)/$@/e2e-top.yaml
 
+.PHONY: test-e2e-upstream-ocp
+test-e2e-upstream-ocp: kustomize-ocp ginkgo-ocp yq-ocp kueuectl-ocp ginkgo-top-ocp run-test-e2e-upstream-ocp-singlecluster
+run-test-e2e-upstream-ocp-singlecluster:
+	@echo "Running e2e tests on OpenShift cluster ($(shell oc whoami --show-server))"
+	ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(GINKGO_ARGS)" \
+	E2E_TARGET_FOLDER="singlecluster" \
+	SKIP_DEPLOY=true \
+	./hack/e2e-test-ocp.sh
+	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/$@/e2e.json > $(ARTIFACTS)/$@/e2e-top.yaml
+
 .PHONY: ginkgo-top-ocp
 ginkgo-top-ocp:
 	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(PROJECT_DIR)/bin/ginkgo-top ./pkg/openshift/ginkgo-top

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -61,6 +61,34 @@ func MakePod(name, ns string) *PodWrapper {
 	}}
 }
 
+func MakeOCPPod(name, ns string) *PodWrapper {
+	return &PodWrapper{corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: make(map[string]string, 1),
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:      "c",
+					Image:     "pause",
+					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}, Limits: corev1.ResourceList{}},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+				},
+			},
+			SchedulingGates: make([]corev1.PodSchedulingGate, 0),
+		},
+	}}
+}
+
 // Obj returns the inner Pod.
 func (p *PodWrapper) Obj() *corev1.Pod {
 	return &p.Pod

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -80,7 +80,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 		})
 
 		ginkgo.It("should admit group that fits", func() {
-			group := podtesting.MakePod("group", ns.Name).
+			group := podtesting.MakeOCPPod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
 				RequestAndLimit(corev1.ResourceCPU, "1").
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 		})
 
 		ginkgo.It("Should only admit a complete group", func() {
-			group := podtesting.MakePod("group", ns.Name).
+			group := podtesting.MakeOCPPod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
 				RequestAndLimit(corev1.ResourceCPU, "1").
@@ -174,7 +174,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			})
 
 			groupName := "group"
-			group := podtesting.MakePod(groupName, ns.Name).
+			group := podtesting.MakeOCPPod(groupName, ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				TerminationGracePeriod(1).
 				Queue(lq.Name).
@@ -289,7 +289,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				eventWatcher.Stop()
 			})
 
-			group := podtesting.MakePod("group", ns.Name).
+			group := podtesting.MakeOCPPod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
 				RequestAndLimit(corev1.ResourceCPU, "1").
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 		})
 
 		ginkgo.It("should allow to schedule a group of diverse pods", func() {
-			group := podtesting.MakePod("group", ns.Name).
+			group := podtesting.MakeOCPPod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
 				RequestAndLimit(corev1.ResourceCPU, "3").
@@ -417,7 +417,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
 			})
 
-			defaultPriorityGroup := podtesting.MakePod("default-priority-group", ns.Name).
+			defaultPriorityGroup := podtesting.MakeOCPPod("default-priority-group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletionFailOnExit).
 				TerminationGracePeriod(1).
 				Queue(lq.Name).
@@ -442,7 +442,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			highPriorityGroup := podtesting.MakePod("high-priority-group", ns.Name).
+			highPriorityGroup := podtesting.MakeOCPPod("high-priority-group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Queue(lq.Name).
 				PriorityClass("high").

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -333,6 +333,11 @@ func CreateNamespaceWithLog(ctx context.Context, k8sClient client.Client, nsName
 func CreateNamespaceFromPrefixWithLog(ctx context.Context, k8sClient client.Client, nsPrefix string) *corev1.Namespace {
 	ginkgo.GinkgoHelper()
 	ns := utiltesting.MakeNamespaceWithGenerateName(nsPrefix)
+	// Add label to the namespace to mark it as managed by Kueue.
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels["kueue.openshift.io/managed"] = "true"
 	gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Created namespace: %s", ns.Name))
 	return ns


### PR DESCRIPTION
```sh
 $ KUEUE_NAMESPACE="openshift-kueue-operator" make -f Makefile-test-ocp.mk test-e2e-upstream-ocp
Makefile-test-ocp.mk:102: warning: overriding recipe for target 'run-test-e2e-ocp-singlecluster'
Makefile-test-ocp.mk:93: warning: ignoring old recipe for target 'run-test-e2e-ocp-singlecluster'
CGO_ENABLED=  go build -ldflags="-X 'sigs.k8s.io/kueue/pkg/version.GitVersion=' -X 'sigs.k8s.io/kueue/pkg/version.GitCommit=9e45b4045c5a4c5c388a2ad531c569f37dd98b66'" -o /home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/bin/kubectl-kueue cmd/kueuectl/main.go
go build -ldflags="-X 'sigs.k8s.io/kueue/pkg/version.GitVersion=' -X 'sigs.k8s.io/kueue/pkg/version.GitCommit=9e45b4045c5a4c5c388a2ad531c569f37dd98b66'" -o /home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/bin/ginkgo-top ./pkg/openshift/ginkgo-top
Running e2e tests on OpenShift cluster (https://api.skunkerk-debug-kueue-upstream-e2e-testsuite.devcluster.openshift.com:6443)
ARTIFACTS="/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/bin/run-test-e2e-ocp-singlecluster" IMAGE_TAG=quay.io/sohankunkerkar/kueue:v1 GINKGO_ARGS="" \
E2E_TARGET_FOLDER="singlecluster" \
SKIP_DEPLOY=true \
./hack/e2e-test-ocp.sh
Skipping cert-manager and kueue deployment because SKIP_DEPLOY is set to true.
Labeling two worker nodes for e2e tests...
node/ip-10-0-20-202.us-east-2.compute.internal not labeled
node/ip-10-0-35-25.us-east-2.compute.internal not labeled
Labeled ip-10-0-20-202.us-east-2.compute.internal as on-demand and ip-10-0-35-25.us-east-2.compute.internal as spot.
Running Suite: End To End Suite:  - /home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster
============================================================================================================================
Random Seed: 1743717706

Will run 31 of 55 specs
------------------------------
[BeforeSuite] 
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/suite_test.go:59
  STEP: Waiting for availability of deployment: "openshift-kueue-operator/kueue-controller-manager" @ 04/03/25 18:01:48.301
  "level"=0 "msg"="Deployment is available in the cluster" "deployment"={"name"="kueue-controller-manager" "namespace"="openshift-kueue-operator"} "waitingTime"="195.477485ms"
  "level"=0 "msg"="Kueue, JobSet, LeaderWorkerSet and AppWrapper operators are available in the cluster" "waitingTime"="195.556832ms"
[BeforeSuite] PASSED [0.199 seconds]
------------------------------
S
------------------------------
StatefulSet integration when StatefulSet created should admit group that fits
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:83
  "level"=0 "msg"="Created namespace: sts-e2e-j46k5"
  STEP: Creating potentially conflicting stateful-set @ 04/03/25 18:01:52.5
  STEP: Check all pods are deleted @ 04/03/25 18:01:57.645
• [9.801 seconds]
------------------------------
StatefulSet integration when StatefulSet created should allow to update the PodTemplate in StatefulSet
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:141
  "level"=0 "msg"="Created namespace: sts-e2e-6fph4"
  STEP: Create a StatefulSet @ 04/03/25 18:01:58.436
  STEP: Waiting for replicas is ready @ 04/03/25 18:01:58.482
  STEP: Update the PodTemplate in StatefulSet @ 04/03/25 18:02:03.611
  STEP: Await for the Pods to be replaced with the new template @ 04/03/25 18:02:03.686
  STEP: Await for the StatefulSet to have all replicas ready again @ 04/03/25 18:02:10.612
• [16.356 seconds]
------------------------------
StatefulSet integration when StatefulSet created should delete all pods on scale down to zero
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:192
  "level"=0 "msg"="Created namespace: sts-e2e-nr9bk"
  STEP: Create StatefulSet @ 04/03/25 18:02:14.806
  STEP: Waiting for replicas is ready @ 04/03/25 18:02:14.858
  STEP: Check workload is created @ 04/03/25 18:02:18.571
  STEP: Scale down replicas to zero @ 04/03/25 18:02:18.603
  STEP: Waiting for replicas is deleted @ 04/03/25 18:02:18.668
  STEP: Check workload is deleted @ 04/03/25 18:02:22.932
• [9.361 seconds]
------------------------------
StatefulSet integration when StatefulSet created should create pods after scale up from zero
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:241
  "level"=0 "msg"="Created namespace: sts-e2e-b7f6p"
  STEP: Create StatefulSet @ 04/03/25 18:02:24.162
  STEP: Scale up replicas @ 04/03/25 18:02:24.215
  STEP: Waiting for replicas is ready @ 04/03/25 18:02:24.284
  STEP: Check workload is created @ 04/03/25 18:02:28.571
• [7.715 seconds]
------------------------------
StatefulSet integration when StatefulSet created should allow to scale up after scale down to zero
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:277
  "level"=0 "msg"="Created namespace: sts-e2e-r8bgn"
  STEP: Create StatefulSet @ 04/03/25 18:02:31.868
  STEP: Waiting for replicas is ready @ 04/03/25 18:02:31.918
  STEP: Check workload is created @ 04/03/25 18:02:35.627
  STEP: Scale down replicas to zero @ 04/03/25 18:02:35.657
  STEP: Wait for ReadyReplicas < 3 @ 04/03/25 18:02:35.726
  STEP: Scale up replicas to zero - retry as it may not be possible immediately @ 04/03/25 18:02:38.07
  STEP: Waiting for replicas is ready @ 04/03/25 18:02:40.699
• [15.014 seconds]
------------------------------
StatefulSet integration when StatefulSet created should allow to change queue name if ReadyReplicas=0
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:340
  "level"=0 "msg"="Created namespace: sts-e2e-nh7m5"
  STEP: Create StatefulSet @ 04/03/25 18:02:46.884
  STEP: Checking that replicas is not ready @ 04/03/25 18:02:46.939
  STEP: Update queue name @ 04/03/25 18:02:47.939
  STEP: Waiting for replicas is ready @ 04/03/25 18:02:48.008
  STEP: Check workload is created @ 04/03/25 18:02:52.882
• [8.972 seconds]
------------------------------
StatefulSet integration when StatefulSet created should delete all Pods if StatefulSet was deleted after being partially ready
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/statefulset_test.go:384
  "level"=0 "msg"="Created namespace: sts-e2e-b6cpq"
  STEP: Create StatefulSet @ 04/03/25 18:02:55.863
  STEP: Check workload is created @ 04/03/25 18:02:55.916
  STEP: Check workload is admitted @ 04/03/25 18:02:55.95
  STEP: Waiting for replicas is partially ready @ 04/03/25 18:02:55.982
  STEP: Delete StatefulSet @ 04/03/25 18:02:57.724
  STEP: Check all pods are deleted @ 04/03/25 18:02:57.759
• [5.425 seconds]
------------------------------
Deployment should admit workloads that fits
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/deployment_test.go:81
  "level"=0 "msg"="Created namespace: deployment-e2e-2wl76"
  STEP: Create a deployment @ 04/03/25 18:03:01.283
  STEP: Wait for replicas ready @ 04/03/25 18:03:01.341
  STEP: Check that workloads are created and admitted @ 04/03/25 18:03:02.878
  STEP: Delete the deployment @ 04/03/25 18:03:02.975
  STEP: Check that workloads are deleted @ 04/03/25 18:03:03.04
• [5.350 seconds]
------------------------------
Deployment should admit workloads after change queue-name if AvailableReplicas = 0
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/deployment_test.go:131
  "level"=0 "msg"="Created namespace: deployment-e2e-4v8r8"
  STEP: Create a deployment @ 04/03/25 18:03:06.64
  STEP: Wait for replicas unavailable @ 04/03/25 18:03:06.694
  STEP: Check that workloads are created but not admitted @ 04/03/25 18:03:07.054
  STEP: Update queue-name on the deployment @ 04/03/25 18:03:07.152
  STEP: Wait for replicas ready @ 04/03/25 18:03:07.222
  STEP: Check previous pods are deleted @ 04/03/25 18:03:10.94
  STEP: Check that workloads are created and admitted @ 04/03/25 18:03:11.011
  STEP: Delete the deployment @ 04/03/25 18:03:11.161
  STEP: Check that workloads are deleted @ 04/03/25 18:03:11.247
• [8.027 seconds]
------------------------------
Kueue when Creating a Job without a matching LocalQueue Should stay in suspended
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:60
  "level"=0 "msg"="Created namespace: e2e-txr4l"
  2025-04-03T18:03:14.735601098-04:00   INFO    KubeAPIWarningLogger    log/warning_handler.go:65       child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning
• [0.580 seconds]
------------------------------
Kueue when Creating a Job With Queueing Should unsuspend a job and set nodeSelectors
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:122
  "level"=0 "msg"="Created namespace: e2e-rchrr"
• [4.712 seconds]
------------------------------
Kueue when Creating a Job With Queueing Should run with prebuilt workload
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:141
  "level"=0 "msg"="Created namespace: e2e-76vpp"
  STEP: Create the pebuilt workload and the job adopting it @ 04/03/25 18:03:19.988
  2025-04-03T18:03:20.025343161-04:00   INFO    KubeAPIWarningLogger    log/warning_handler.go:65       unknown field "spec.podSets[0].template.metadata.creationTimestamp"
  STEP: Verify the prebuilt workload is adopted by the job @ 04/03/25 18:03:20.091
  STEP: Verify the job is running @ 04/03/25 18:03:20.16
  STEP: Await for pods to be running @ 04/03/25 18:03:20.19
  STEP: Delete all pods @ 04/03/25 18:03:20.221
  STEP: Await for jobs completion @ 04/03/25 18:03:20.292
• [2.389 seconds]
------------------------------
Kueue when Creating a Job With Queueing Should readmit preempted job with priorityClass into a separate flavor
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:213
  "level"=0 "msg"="Created namespace: e2e-6r2bc"
  STEP: Job is admitted using the first flavor @ 04/03/25 18:03:22.493
  STEP: Job is preempted by higher priority job @ 04/03/25 18:03:22.52
  STEP: Job is re-admitted using the second flavor @ 04/03/25 18:03:23.183
• [3.013 seconds]
------------------------------
Kueue when Creating a Job With Queueing Should readmit preempted job with workloadPriorityClass into a separate flavor
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:249
  "level"=0 "msg"="Created namespace: e2e-ptx6w"
  STEP: Job is admitted using the first flavor @ 04/03/25 18:03:25.481
  STEP: Job is preempted by higher priority job @ 04/03/25 18:03:25.515
  STEP: Job is re-admitted using the second flavor @ 04/03/25 18:03:26.454
• [2.982 seconds]
------------------------------
Kueue when Creating a Job With Queueing Should partially admit the Job if configured and not fully fits
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:284
  "level"=0 "msg"="Created namespace: e2e-wsxxr"
  STEP: Wait for the job to start and check the updated Parallelism and Completions @ 04/03/25 18:03:28.427
  STEP: Wait for the job to finish @ 04/03/25 18:03:28.499
• [7.587 seconds]
------------------------------
Kueue when Creating a Job In a Twostepadmission Queue Should unsuspend a job only after all checks are cleared
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:361
  "level"=0 "msg"="Created namespace: e2e-jnrdc"
  STEP: verify the check is added to the workload @ 04/03/25 18:03:36.113
  STEP: waiting for the workload to be assigned @ 04/03/25 18:03:36.44
  STEP: checking the job remains suspended @ 04/03/25 18:03:36.471
  STEP: setting the check as successful @ 04/03/25 18:03:37.471
• [5.989 seconds]
------------------------------
Kueue when Creating a Job In a Twostepadmission Queue Should suspend a job when its checks become invalid
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/e2e_test.go:417
  "level"=0 "msg"="Created namespace: e2e-rq6fr"
  STEP: verify the check is added to the workload @ 04/03/25 18:03:42.067
  STEP: setting the check as successful @ 04/03/25 18:03:42.098
  STEP: setting the check as Rejected @ 04/03/25 18:03:42.199
  STEP: checking the job gets suspended @ 04/03/25 18:03:42.273
• [2.393 seconds]
------------------------------
Kueuectl Create when Creating a LocalQueue Should create local queue
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/kueuectl_test.go:52
  "level"=0 "msg"="Created namespace: e2e-c27qv"
  STEP: Create local queue by kueuectl @ 04/03/25 18:03:44.235
  STEP: Check that the local queue successfully created @ 04/03/25 18:03:44.458
• [0.747 seconds]
------------------------------
Kueuectl Create when Creating a LocalQueue Shouldn't create local queue with unknown cluster queue
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/kueuectl_test.go:71
  "level"=0 "msg"="Created namespace: e2e-7h8gb"
  STEP: Create local queue by kueuectl @ 04/03/25 18:03:44.982
  STEP: Check that the local queue did not create @ 04/03/25 18:03:45.136
• [0.689 seconds]
------------------------------
SS
------------------------------
Pod groups when Single CQ should admit group that fits
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/pod_test.go:82
  "level"=0 "msg"="Created namespace: pod-e2e-vf4mc"
  STEP: Starting admission @ 04/03/25 18:03:45.858
  STEP: Deleting finished Pods @ 04/03/25 18:03:47.937
• [3.120 seconds]
------------------------------
Pod groups when Single CQ Should only admit a complete group
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/pod_test.go:125
  "level"=0 "msg"="Created namespace: pod-e2e-vgbj7"
  STEP: Incomplete group should not start @ 04/03/25 18:03:48.859
  STEP: Incomplete group can be deleted @ 04/03/25 18:03:49.966
  STEP: Complete group runs successfully @ 04/03/25 18:03:50.096
• [7.014 seconds]
------------------------------
S
------------------------------
Pod groups when Single CQ Unscheduled Pod which is deleted can be replaced in group
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/pod_test.go:281
  "level"=0 "msg"="Created namespace: pod-e2e-xskds"
  STEP: Group starts @ 04/03/25 18:03:55.912
  STEP: Check the second pod is no longer pending @ 04/03/25 18:03:56.366
  STEP: Check the first pod is Unschedulable @ 04/03/25 18:03:58.101
  STEP: Deleting the pod it remains Unschedulable @ 04/03/25 18:03:58.131
  STEP: Replacement pod is un-gated, and the failed one is deleted @ 04/03/25 18:03:58.202
• [3.569 seconds]
------------------------------
S
------------------------------
Pod groups when Single CQ should allow to preempt the lower priority group
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/pod_test.go:403
  "level"=0 "msg"="Created namespace: pod-e2e-mm54j"
  STEP: Default-priority group starts @ 04/03/25 18:03:59.511
  STEP: Create the high-priority group @ 04/03/25 18:03:59.96
  STEP: The default priority workload is preempted @ 04/03/25 18:04:00.415
  STEP: Use events to observe the default-priority pods are getting preempted @ 04/03/25 18:04:00.483
  STEP: Wait for default-priority pods to fail @ 04/03/25 18:04:00.483
  STEP: Create replacement pods @ 04/03/25 18:04:05.359
  STEP: Check that the preempted pods are deleted @ 04/03/25 18:04:05.476
  STEP: Verify the high-priority pods are scheduled @ 04/03/25 18:04:05.546
  STEP: Call high priority group pods to complete @ 04/03/25 18:04:05.611
  STEP: Verify the high priority group completes @ 04/03/25 18:04:10.824
  STEP: Await for the replacement pods to be ungated @ 04/03/25 18:04:13.116
  STEP: Verify the replacement pods of the default priority workload complete @ 04/03/25 18:04:13.176
  STEP: Verify the default priority workload is finished @ 04/03/25 18:04:17.204
• [18.630 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSS
------------------------------
Kueue visibility server when There are pending workloads due to capacity maxed by the admitted job Should allow fetching information about pending workloads in ClusterQueue
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:136
  "level"=0 "msg"="Created namespace: e2e-b7pz8"
  "level"=0 "msg"="Created namespace: e2e-bkcc7"
  STEP: Schedule a job that when admitted workload blocks the queue @ 04/03/25 18:04:18.29
  STEP: Ensure the workload is admitted, by awaiting until the job is unsuspended @ 04/03/25 18:04:18.338
  STEP: Verify there are zero pending workloads @ 04/03/25 18:04:18.65
  STEP: Schedule a job which is pending due to lower priority @ 04/03/25 18:04:18.679
  STEP: Verify there is one pending workload @ 04/03/25 18:04:18.724
  STEP: Await for pods to be running @ 04/03/25 18:04:18.753
  STEP: Terminate execution of the first workload to release the quota @ 04/03/25 18:04:21.054
  STEP: Verify there are zero pending workloads, after the second workload is admitted @ 04/03/25 18:04:21.127
• [5.996 seconds]
------------------------------
Kueue visibility server when There are pending workloads due to capacity maxed by the admitted job Should allow fetching information about position of pending workloads in ClusterQueue
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:182
  "level"=0 "msg"="Created namespace: e2e-5jrzd"
  "level"=0 "msg"="Created namespace: e2e-7gjfm"
  STEP: Schedule a job that when admitted workload blocks the queue @ 04/03/25 18:04:24.247
  STEP: Ensure the workload is admitted, by awaiting until the job is unsuspended @ 04/03/25 18:04:24.29
  STEP: Schedule three different jobs with different priorities and two different LocalQueues @ 04/03/25 18:04:24.325
  STEP: Verify their positions and priorities @ 04/03/25 18:04:24.463
• [2.265 seconds]
------------------------------
Kueue visibility server when There are pending workloads due to capacity maxed by the admitted job Should allow fetching information about pending workloads in LocalQueue
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:257
  "level"=0 "msg"="Created namespace: e2e-h5tsb"
  "level"=0 "msg"="Created namespace: e2e-qpxkq"
  STEP: Schedule a job that when admitted workload blocks the queue @ 04/03/25 18:04:26.506
  STEP: Ensure the workload is admitted, by awaiting until the job is unsuspended @ 04/03/25 18:04:26.552
  STEP: Verify there are zero pending workloads @ 04/03/25 18:04:26.584
  STEP: Schedule a job which is pending due to lower priority @ 04/03/25 18:04:26.613
  STEP: Verify there is one pending workload @ 04/03/25 18:04:26.658
  STEP: Await for pods to be running @ 04/03/25 18:04:26.687
  STEP: Terminate execution of the first workload to release the quota @ 04/03/25 18:04:28.97
  STEP: Verify there are zero pending workloads, after the second workload is admitted @ 04/03/25 18:04:29.046
• [5.717 seconds]
------------------------------
Kueue visibility server when There are pending workloads due to capacity maxed by the admitted job Should allow fetching information about position of pending workloads from different LocalQueues
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:303
  "level"=0 "msg"="Created namespace: e2e-qdh8b"
  "level"=0 "msg"="Created namespace: e2e-csst6"
  STEP: Schedule a job that when admitted workload blocks the queue @ 04/03/25 18:04:32.233
  STEP: Ensure the workload is admitted, by awaiting until the job is unsuspended @ 04/03/25 18:04:32.275
  STEP: Schedule three different jobs with different priorities and two different LocalQueues @ 04/03/25 18:04:32.309
  STEP: Verify their positions and priorities in LocalQueueA @ 04/03/25 18:04:32.452
  STEP: Verify their positions and priorities in LocalQueueB @ 04/03/25 18:04:32.483
• [2.343 seconds]
------------------------------
Kueue visibility server when There are pending workloads due to capacity maxed by the admitted job Should allow fetching information about position of pending workloads from different LocalQueues from different Namespaces
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:387
  "level"=0 "msg"="Created namespace: e2e-t5tw7"
  "level"=0 "msg"="Created namespace: e2e-cl8qh"
  STEP: Schedule a job that when admitted workload blocks the queue @ 04/03/25 18:04:34.563
  STEP: Ensure the workload is admitted, by awaiting until the job is unsuspended @ 04/03/25 18:04:34.615
  STEP: Create a LocalQueue in a different Namespace @ 04/03/25 18:04:34.646
  STEP: Schedule three different jobs with different priorities and different LocalQueues in different Namespaces @ 04/03/25 18:04:34.693
  STEP: Verify their positions and priorities in LocalQueueA @ 04/03/25 18:04:34.832
  STEP: Verify their positions and priorities in LocalQueueB @ 04/03/25 18:04:34.864
• [2.907 seconds]
------------------------------
Kueue visibility server when A subject is bound to kueue-batch-admin-role Should return an appropriate error
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:506
  "level"=0 "msg"="Created namespace: e2e-vnsg7"
  "level"=0 "msg"="Created namespace: e2e-trcbh"
  STEP: Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work @ 04/03/25 18:04:37.297
  STEP: Returning a ResourceNotFound error for a nonexistent ClusterQueue @ 04/03/25 18:04:37.328
  STEP: Returning a ResourceNotFound error for a nonexistent LocalQueue @ 04/03/25 18:04:37.357
• [0.989 seconds]
------------------------------
Kueue visibility server when A subject is bound to kueue-batch-user-role, but not to kueue-batch-admin-role Should return an appropriate error
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:542
  "level"=0 "msg"="Created namespace: e2e-r786r"
  "level"=0 "msg"="Created namespace: e2e-wcg2b"
  STEP: Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work @ 04/03/25 18:04:38.282
  STEP: Returning a Forbidden error due to insufficient permissions for the ClusterQueue request @ 04/03/25 18:04:38.313
  STEP: Returning a ResourceNotFound error for a nonexistent LocalQueue @ 04/03/25 18:04:38.34
  STEP: Returning a Forbidden error due to insufficient permissions for the LocalQueue request in different namespace @ 04/03/25 18:04:38.372
• [0.991 seconds]
------------------------------
Kueue visibility server when A subject is not bound to kueue-batch-user-role, nor to kueue-batch-admin-role Should return an appropriate error
/home/skunkerk/dev/src/github.com/openshift/kubernetes-sigs-kueue/test/e2e/singlecluster/visibility_test.go:559
  "level"=0 "msg"="Created namespace: e2e-d2s8p"
  "level"=0 "msg"="Created namespace: e2e-zpkfl"
  STEP: Returning a Forbidden error due to insufficient permissions for the ClusterQueue request @ 04/03/25 18:04:39.21
  STEP: Returning a Forbidden error due to insufficient permissions for the LocalQueue request @ 04/03/25 18:04:39.243
• [0.849 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --json-report --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.008 seconds]
------------------------------

Ran 31 of 55 Specs in 171.693 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 24 Skipped
PASS

```