### PR TITLE
use ubi-minimal for fips

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro@sha256:3d7dff3c85eb3c248d121407ef4b6ac0002a7f8ff565eab5a2d92e63be766a31
+ARG BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal@sha256:e1c4703364c5cb58f5462575dc90345bcd934ddc45e6c32f9c162f2b5617681c
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder


### PR DESCRIPTION
ubi-minimal has openssl library which is required for fips.