### PR TITLE
Skip flaky StatefulSet test

### DIFF
--- a/hack/e2e-test-ocp.sh
+++ b/hack/e2e-test-ocp.sh
@@ -156,7 +156,7 @@ if [ "$SKIP_DEPLOY" != "true" ]; then
     GINKGO_SKIP_PATTERN="(AppWrapper|JobSet|LeaderWorkerSet|Pod|Deployment|StatefulSet|Metrics|Fair Sharing|TopologyAwareScheduling)"
 else
     echo "Skipping cert-manager and kueue deployment because SKIP_DEPLOY is set to true."
-    GINKGO_SKIP_PATTERN="(AppWrapper|JobSet|LeaderWorkerSet|Metrics|Fair Sharing|TopologyAwareScheduling|Kueue visibility server|Failed Pod can be replaced in group|should allow to schedule a group of diverse pods)"
+    GINKGO_SKIP_PATTERN="(AppWrapper|JobSet|LeaderWorkerSet|Metrics|Fair Sharing|TopologyAwareScheduling|Kueue visibility server|Failed Pod can be replaced in group|should allow to schedule a group of diverse pods|should allow to change queue name if ReadyReplicas=0)"
 fi
 
 # Label two worker nodes for e2e tests (similar to the Kind setup).


### PR DESCRIPTION
The following test is often failing in our CI `[FAIL] StatefulSet integration when StatefulSet created [It] should allow to change queue name if ReadyReplicas=0`. Given that there is already an issue reported about it in [kubernetes-sigs/kueue](https://github.com/kubernetes-sigs/kueue/issues/5041), let's skip the issue for now and remove the skip once it's fixed.