### PR TITLE
add a sleep for cert manager

### DIFF
--- a/hack/e2e-test-ocp.sh
+++ b/hack/e2e-test-ocp.sh
@@ -148,6 +148,7 @@ trap collect_logs EXIT
 GINKGO_SKIP_PATTERN=""
 if [ "$SKIP_DEPLOY" != "true" ]; then
     deploy_cert_manager
+    sleep 3m
     deploy_kueue
     # Skip e2e tests that depend on pod integration features,
     # such as Deployment and StatefulSet, or other integrations not


### PR DESCRIPTION
As I am working on https://github.com/openshift/kubernetes-sigs-kueue/pull/196, I am hitting problems where cert manager is not actually fully ready. 

When this happens I am getting cert manager rejecting the deployment of Kueue. In the other PR, I added a sleep for a few minutes which seems to resolve this issue.