### PR TITLE
Add s390x support to pipeline multi-arch build

### DIFF
--- a/.tekton/kubernetes-sigs-kueue-main-pull-request.yaml
+++ b/.tekton/kubernetes-sigs-kueue-main-pull-request.yaml
@@ -29,7 +29,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux/x86_64,linux/s390x
   - name: dockerfile
     value: Dockerfile.rhel
   pipelineSpec:


### PR DESCRIPTION
## PR Description


Added s390x architecture to the pipeline build platforms, enabling multi-arch image builds for s390x.


## What type of PR is this?

/kind feature

## What this PR does / why we need it

This PR adds `s390x` to the multi-architecture build platforms in the Tekton pipeline definition (`.tekton/kubernetes-sigs-kueue-main-pull-request.yaml`).  
With this change, images will be built for both `linux/x86_64` and `linux/s390x` architectures, enabling support for s390x systems.

## Note:

- The `Dockerfile.rhel` already supports multi-arch builds using `TARGETARCH` and `TARGETPLATFORM`.
- No changes were needed in the Dockerfile.
- E2E tests have passed for s390x locally.


