### PR TITLE
Add s390x support to release-0.12 pipeline

### DIFF
--- a/.tekton/kueue-0-12-pull-request.yaml
+++ b/.tekton/kueue-0-12-pull-request.yaml
@@ -31,7 +31,6 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
-    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:

--- a/.tekton/kueue-0-12-pull-request.yaml
+++ b/.tekton/kueue-0-12-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:

--- a/.tekton/kueue-0-12-push.yaml
+++ b/.tekton/kueue-0-12-push.yaml
@@ -28,7 +28,6 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
-    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:

--- a/.tekton/kueue-0-12-push.yaml
+++ b/.tekton/kueue-0-12-push.yaml
@@ -27,6 +27,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:


### PR DESCRIPTION
PR Description

Added s390x & power architecture to the pipeline build platforms, enabling multi-arch image builds for s390x for branch release-0.12.

What type of PR is this?

/kind feature

What this PR does / why we need it

This PR adds s390x & power to the multi-architecture build platforms in the Tekton pipeline definition (.tekton/kueue-0-12-pull-request.yaml & .tekton/kueue-0-12-push-request.yaml).
With this change, images will be built for linux/x86_64,linux/ppc64le and linux/s390x architectures, enabling support for s390x & power systems.

Note:

The Dockerfile.rhel already supports multi-arch builds using TARGETARCH and TARGETPLATFORM.
No changes were needed in the Dockerfile.
E2E tests have passed for s390x locally.