### PR TITLE
MULTIARCH-5625: Adding support for ppc64le for kueue on release-0.12

### DIFF
--- a/.tekton/kueue-0-12-pull-request.yaml
+++ b/.tekton/kueue-0-12-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:

--- a/.tekton/kueue-0-12-push.yaml
+++ b/.tekton/kueue-0-12-push.yaml
@@ -28,6 +28,7 @@ spec:
     value:
     - linux/x86_64
     - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: /Dockerfile.rhel
   pipelineSpec:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds ppc64le support to the operator for Kueue release-0.12

#### Which issue(s) this PR fixes:
[MULTIARCH-5625](https://issues.redhat.com/browse/MULTIARCH-5625)

#### Special notes for your reviewer:
See https://github.com/openshift/kueue-operator/pull/532
See https://github.com/openshift/kubernetes-sigs-kueue/pull/255

#### Does this PR introduce a user-facing change?
not at this time