### PR TITLE
Make RayJob a TopLevelJob

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -76,6 +76,7 @@ type RayCluster rayv1.RayCluster
 
 var _ jobframework.GenericJob = (*RayCluster)(nil)
 var _ jobframework.JobWithManagedBy = (*RayCluster)(nil)
+var _ jobframework.TopLevelJob = (*RayCluster)(nil)
 
 func (j *RayCluster) Object() client.Object {
 	return (*rayv1.RayCluster)(j)
@@ -226,4 +227,8 @@ func (j *RayCluster) ManagedBy() *string {
 
 func (j *RayCluster) SetManagedBy(managedBy *string) {
 	j.Spec.ManagedBy = managedBy
+}
+
+func (j *RayCluster) IsTopLevel() bool {
+	return !jobframework.IsOwnerManagedByKueueForObject(j.Object())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces a key distinction for Kueue to correctly handle two separate use cases: jobs submitted via RayJob CRs and jobs submitted to an existing standalone RayCluster.

* **The Problem:** When a user submits a RayJob CR, Kuberay lifecycles a RayCluster to run the Job. Without this change, Kueue would see two separate objects (RayJob and RayCluster) that both appear to need scheduling, resulting in a duplicate workload, essentially halving the kueue resource constraints.

* **The Solution**: This PR makes RayJob a TopLevelJob. Now, when Kueue processes a RayCluster, it checks its owner reference. If the owner is a RayJob that Kueue is already managing, Kueue understands that the cluster is just a component of that job and does not create a new, redundant workload for it. This correctly associates the cluster's resources with the parent RayJob's workload. If a standalone RayCluster is created and labelled for Kueue processing, it won't have an owner reference and so Kueue will handle it as such.