### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kueue-0-12

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -21,7 +21,8 @@ COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 LABEL com.redhat.component="Kueue"
-LABEL name="kueue"
+LABEL cpe="cpe:/a:redhat:kueue_operator:1.1::el9"
+LABEL name="kueue/kueue-rhel9"
 LABEL url="https://github.com/openshift/kubernetes-sigs-kueue"
 LABEL vendor="Red Hat, Inc."
 LABEL description="Kueue is a set of APIs and controller for job queueing. \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
